### PR TITLE
Refactor embedding creation logic. Model download/ initialisation now working. Datasets not working

### DIFF
--- a/src/common/base.py
+++ b/src/common/base.py
@@ -89,7 +89,7 @@ class Embeddings(BaseModel):
 
     @staticmethod
     def build_embedding(
-        self, model: CLIPModel, dataset: HFDataset, batch_size: int = 50
+        model: CLIPModel, dataset: HFDataset, batch_size: int = 50
     ) -> "Embeddings":
         def _collate_fn(examples) -> dict[str, torch.tensor]:
             images = []
@@ -102,14 +102,14 @@ class Embeddings(BaseModel):
             labels = torch.tensor(labels)
             return {"pixel_values": pixel_values, "labels": labels}
 
-        transformed_dataset = dataset.dataset.set_transform(self.process_fn)
+        transformed_dataset = dataset.dataset.set_transform(model.process_fn)
         dataloader = DataLoader(
             transformed_dataset, collate_fn=_collate_fn, batch_size=batch_size
         )
         tmp_embeddings = []
         tmp_labels = []
         with torch.inference_mode():
-            for batch in tqdm(dataloader, desc=f"Embedding dataset with {self.title}"):
+            for batch in tqdm(dataloader, desc=f"Embedding dataset with {model.title}"):
                 tmp_labels.append(batch["label"])
                 features = model.get_image_features(pixel_values=batch["pixel_values"])
                 emb = (features / features.norm(p=2, dim=-1, keepdim=True)).squeeze()

--- a/src/common/data_models.py
+++ b/src/common/data_models.py
@@ -59,8 +59,8 @@ class EmbeddingDefinition(BaseModel):
         embeddings.to_file(self.embedding_path)
         return True
 
-    def build_embedding(self) -> Embeddings:
-        return EmbeddingDefinition.from_embedding_definition(self.model, self.dataset)
+    def build_embeddings(self) -> Embeddings:
+        return Embeddings.from_embedding_definition(self.model, self.dataset)
 
 
 if __name__ == "__main__":
@@ -93,3 +93,10 @@ if __name__ == "__main__":
         assert False
     except ValidationError:
         assert True
+
+    def_ = EmbeddingDefinition(
+        model="openai/clip-vit-large-patch14-336",
+        dataset="Kabil007/LungCancer4Types",
+    )
+    embeddings = def_.build_embeddings()
+    def_.save_embeddings(embeddings)

--- a/src/common/string_utils.py
+++ b/src/common/string_utils.py
@@ -1,8 +1,12 @@
-KEEP_CHARACTERS = set([".", "_", " "])
+KEEP_CHARACTERS = set([".", "_", " ", "-", "/"])
 REPLACE_CHARACTERS = {" ": "_"}
 
 
 def safe_str(unsafe: str) -> str:
     if not isinstance(unsafe, str):
         raise ValueError(f"{unsafe} ({type(unsafe)}) not a string")
-    return "".join(REPLACE_CHARACTERS.get(c, c) for c in unsafe if c.isalnum() or c in KEEP_CHARACTERS).rstrip()
+    return "".join(
+        REPLACE_CHARACTERS.get(c, c)
+        for c in unsafe
+        if c.isalnum() or c in KEEP_CHARACTERS
+    ).rstrip()

--- a/src/dataset/dataset.py
+++ b/src/dataset/dataset.py
@@ -1,13 +1,16 @@
-from datasets import load_dataset
+from datasets import Dataset, DatasetDict, load_dataset
 
 
 class HFDataset:
     def __init__(self, dataset_name) -> None:
         self.dataset = self._load_dataset(dataset_name)
 
-    def _load_dataset(self, dataset_name):
+    def _load_dataset(self, dataset_name) -> Dataset:
         try:
-            self.dataset = load_dataset(dataset_name)
+            dataset = load_dataset(dataset_name)
         except Exception:
             self.dataset = None
             raise ValueError(f"Failed to load dataset from HF {dataset_name}")
+        if isinstance(dataset, DatasetDict):
+            dataset = dataset["train"]
+        return dataset

--- a/src/models/CLIP_model.py
+++ b/src/models/CLIP_model.py
@@ -18,7 +18,7 @@ model_name = options[short_name]
 
 
 class CLIPModel:
-    def __init__(self, model_name: str, device: str = torch.device("cuda")) -> None:
+    def __init__(self, model_name: str, device: str = torch.device("cpu")) -> None:
         self.model = HF_ClipModel.from_pretrained(model_name).to(device)
         self.title = model_name
         self.processor = CLIPProcessor.from_pretrained(model_name)


### PR DESCRIPTION
Changes made to safe strings probably not necessary but was used to pass strings from data_models to CLIP_model.py.

Also a smaller model should be picked for testing. As is, is 1.7GB which is cached but slowww to download. Obstruction to datasets is dealing with different formats being downloaded and potentially different transforms needed. Currently stored in model.process_fn