### PR TITLE
fix: Tidy names

### DIFF
--- a/src/dataset/dataset.py
+++ b/src/dataset/dataset.py
@@ -3,12 +3,12 @@ from datasets import Dataset, Split, load_dataset
 DATASETS = {
     "LungCancer4Types": "Kabil007/LungCancer4Types",
     "plants": "sampath017/plants",
-    "NIH-Chest-X-ray": "alkzar90/NIH-Chest-X-ray-dataset",
+    "NIH_Chest_X_ray": "alkzar90/NIH-Chest-X-ray-dataset",
     "Alzheimer_MRI": "Falah/Alzheimer_MRI",
     "Skin_cancer": "marmal88/skin_cancer",
-    "chest-xray-classification": "tpakov/chest-xray-classification",
-    "sports-classification": "HES-XPLAIN/SportsImageClassification",
-    "geo-landmarks": "Qdrant/google-landmark-geo",
+    "chest_xray_classification": "tpakov/chest-xray-classification",
+    "sports_classification": "HES-XPLAIN/SportsImageClassification",
+    "geo_landmarks": "Qdrant/google-landmark-geo",
 }
 
 

--- a/src/models/CLIP_model.py
+++ b/src/models/CLIP_model.py
@@ -13,7 +13,7 @@ OPTIONS = {
     # "sigLIP": "timm/ViT-SO400M-14-SigLIP-384" doesn't worj needs more open_clip style loading
     "apple": "apple/DFN5B-CLIP-ViT-H-14",  #  this is huge
     # "pmc": "ryanyip7777/pmc_vit_l_14",  # pmc open access dataset also open-clip
-    "eva-clip": "BAAI/EVA-CLIP-8B-448",  # This is ginormous
+    "eva_clip": "BAAI/EVA-CLIP-8B-448",  # This is ginormous
     "fashion": "patrickjohncyh/fashion-clip",
     "rscid": "flax-community/clip-rsicd",
     "bioclip": "imageomics/bioclip",


### PR DESCRIPTION
Models/datasets with - in the name won't pass safe_names as they won't form good folder names.
Thus: Swap out - (unsafe) for - safe