### PR TITLE
Small PR allowing the animate CLI to take in 2 models

### DIFF
--- a/clip_eval/cli/main.py
+++ b/clip_eval/cli/main.py
@@ -111,7 +111,7 @@ def animate_embeddings():
     from clip_eval.plotting.animation import build_animation, save_animation_to_file
 
     # Error could be localised better
-    defns = select_existing_embedding_definitions(by_dataset=True)
+    defns = select_existing_embedding_definitions(by_dataset=True, select_pair=True)
     assert len(defns) == 2, "Please select exactly two models to make animation"
     def1 = max(defns, key=lambda d: int(d.model == "clip"))
     def2 = defns[0] if defns[0] != def1 else defns[1]

--- a/clip_eval/cli/utils.py
+++ b/clip_eval/cli/utils.py
@@ -40,14 +40,17 @@ def _by_dataset(defs: list[EmbeddingDefinition] | dict[str, list[EmbeddingDefini
 
 def select_existing_embedding_definitions(
     by_dataset: bool = False,
+    select_pair: bool = False,
 ) -> list[EmbeddingDefinition]:
     defs = read_all_cached_embeddings(as_list=True)
 
     if by_dataset:
         # Subset definitions to specific dataset
         defs = _by_dataset(defs)
-
-    return _do_embedding_definition_selection(defs)
+    if select_pair:
+        return _do_embedding_definition_selection(defs) + _do_embedding_definition_selection(defs)
+    else:
+        return _do_embedding_definition_selection(defs)
 
 
 def select_from_all_embedding_definitions(

--- a/clip_eval/plotting/animation.py
+++ b/clip_eval/plotting/animation.py
@@ -37,7 +37,6 @@ def rotate_to_target(source: N2Array, destination: N2Array):
 
     rot, *_ = R.align_vectors(source, destination, return_sensitivity=True)
     out = source @ rot.as_matrix()
-    print(out[:, 2].std())
     return out[:, :2]
 
 


### PR DESCRIPTION
Current behaviour is that we select a singular model definition and then it will fail to make an animation. Also it would be good to introduce the ability to select multiple models in the evaluation. Ideally having the first option be halt and the others being select a model. I'll try write that but I'm a bit confused by this interface.