### PR TITLE
print results tabulated

### DIFF
--- a/clip_eval/cli/main.py
+++ b/clip_eval/cli/main.py
@@ -98,7 +98,6 @@ def evaluate_embeddings(
     performances = run_evaluation(models, defns)
     if save:
         export_evaluation_to_csv(defns, performances)
-    print(performances)
 
 
 @cli.command(

--- a/clip_eval/evaluation/linear_probe.py
+++ b/clip_eval/evaluation/linear_probe.py
@@ -28,7 +28,7 @@ class LinearProbeClassifier(ClassificationModel):
             labels: The labels associated to the embeddings
             num_classes: If not specified will be inferred from the labels.
         """
-        super().__init__("linear-probe")
+        super().__init__("linear_probe")
         self.num_classes = num_classes or labels.max() + 1
 
         embeddings = self.normalize(embeddings)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2918,6 +2918,20 @@ files = [
 mpmath = ">=0.19"
 
 [[package]]
+name = "tabulate"
+version = "0.9.0"
+description = "Pretty-print tabular data"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
+    {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
+]
+
+[package.extras]
+widechars = ["wcwidth"]
+
+[[package]]
 name = "termcolor"
 version = "2.4.0"
 description = "ANSI color formatting for output in terminal"
@@ -3658,4 +3672,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "1dedd05abfb052782b1712572fb6541df367b354da098124fee819c5bd611962"
+content-hash = "8702169b5072427bb0e6817930c9149b0ec5ef093bea3cfd13b10625b8a3e3eb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ umap-learn = "^0.5.5"
 matplotlib = "^3.8.2"
 typer = "^0.9.0"
 inquirerpy = "^0.3.4"
+tabulate = "^0.9.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.8.0"


### PR DESCRIPTION
When running `clip-eval evaluate` all combinations of models and datasets will be printed in tables similar to these:

```
===== wKNN =====
-------------  ----------------  -------------  ------  -------------
Model/Dataset  LungCancer4Types  Alzheimer-MRI  plants  Alzheimer_MRI
plip           0.2167            0.4505         -       -
pubmed         0.2067            0.4499         -       0.4499
clip           0.2200            0.4518         0.5455  -
tinyclip       0.2167            -              0.6364  -
-------------  ----------------  -------------  ------  -------------
===== linear_probe =====
-------------  ----------------  -------------  ------  -------------
Model/Dataset  LungCancer4Types  Alzheimer-MRI  plants  Alzheimer_MRI
plip           0.5267            0.5469         -       -
pubmed         0.5400            0.5482         -       0.5482
clip           0.5700            0.5521         1.0000  -
tinyclip       0.5733            -              1.0000  -
-------------  ----------------  -------------  ------  -------------
```