### PR TITLE
fix: SigLip.to(device)

### DIFF
--- a/clip_eval/models/CLIP_model.py
+++ b/clip_eval/models/CLIP_model.py
@@ -127,7 +127,7 @@ class SiglipModel(CLIPModel):
         self._setup()
 
     def _setup(self, **kwargs):
-        self.model = HF_SiglipModel.from_pretrained(self.title_in_source)
+        self.model = HF_SiglipModel.from_pretrained(self.title_in_source).to(self.device)
         self.processor = HF_SiglipProcessor.from_pretrained(self.title_in_source)
         self.process_fn = self.define_process_fn()
 


### PR DESCRIPTION
Mistake made by me (I wrote some of the code manually rather than Ctrl+c ctrl+V).
Was discovered on the VM with error:
```
RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same
```
Very simple fix. Tested on VM that it is failing on main and successful on this branch.