### PR TITLE
chore: store models in the global cache

### DIFF
--- a/clip_eval/constants.py
+++ b/clip_eval/constants.py
@@ -5,13 +5,13 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-_CACHE_PATH = Path(os.environ.get("CLIP_CACHE_PATH", ".cache"))
+CACHE_PATH = Path(os.environ.get("CLIP_CACHE_PATH", ".cache"))
 _OUTPUT_PATH = Path(os.environ.get("OUTPUT_PATH", "output"))
 
 
 class PROJECT_PATHS:
-    EMBEDDINGS = _CACHE_PATH / "embeddings"
-    REDUCTIONS = _CACHE_PATH / "reductions"
+    EMBEDDINGS = CACHE_PATH / "embeddings"
+    REDUCTIONS = CACHE_PATH / "reductions"
 
 
 class NPZ_KEYS:

--- a/clip_eval/models/CLIP_model.py
+++ b/clip_eval/models/CLIP_model.py
@@ -14,7 +14,7 @@ from transformers import SiglipModel as HF_SiglipModel
 from transformers import SiglipProcessor as HF_SiglipProcessor
 
 from clip_eval.common.numpy_types import ClassArray, EmbeddingArray
-from clip_eval.constants import _CACHE_PATH
+from clip_eval.constants import CACHE_PATH
 
 
 class CLIPModel(ABC):
@@ -33,7 +33,7 @@ class CLIPModel(ABC):
         self._check_device(device)
         self.__device = torch.device(device)
         if cache_dir is None:
-            cache_dir = _CACHE_PATH
+            cache_dir = CACHE_PATH
         self._cache_dir = Path(cache_dir).expanduser().resolve() / "models"
 
     @property


### PR DESCRIPTION
Now models aren't stored in each user's cache folder, but in the project's root `.cache` folder, thus avoiding duplicate weights downloads.