### PR TITLE
feat: enable multiuser access to HF datasets

### DIFF
--- a/clip_eval/dataset/dataset.py
+++ b/clip_eval/dataset/dataset.py
@@ -118,3 +118,7 @@ class HFDataset(Dataset):
 
         except Exception as e:
             raise ValueError(f"Failed to load dataset from Hugging Face: {self.title_in_source}") from e
+
+    def __del__(self):
+        for f in self._cache_dir.glob("**/*.lock"):
+            f.unlink(missing_ok=True)


### PR DESCRIPTION
Dirty lock files generated by a dependency of HF prevent users from accessing datasets downloaded by other users. The deletion of the offending files is sufficient to enable the expected multiuser access to datasets.

@Jim-Encord helped prove that the behaviour is as expected in the VM.