### PR TITLE
feat: avoid refetch of downloaded encord data

### DIFF
--- a/clip_eval/dataset/encord.py
+++ b/clip_eval/dataset/encord.py
@@ -1,6 +1,8 @@
 import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from encord import EncordUserClient
 from encord.objects import Classification, LabelRowV2
@@ -12,6 +14,7 @@ from .encord_utils import (
     download_data_from_project,
     get_frame_file,
     get_label_row_annotations_file,
+    get_label_rows_info_file,
     simple_project_split,
 )
 
@@ -34,9 +37,9 @@ class EncordDataset(Dataset):
         self._setup(project_hash, classification_hash, ssh_key_path, **kwargs)
 
     def __getitem__(self, idx):
-        frame_path = self._frame_paths[idx]
+        frame_path = self._dataset_indices_info[idx].image_file
         img = Image.open(frame_path)
-        label = self._labels[idx]
+        label = self._dataset_indices_info[idx].label
 
         if self.transform is not None:
             _d = self.transform(dict(image=[img], label=[label]))
@@ -46,9 +49,9 @@ class EncordDataset(Dataset):
         return res_item
 
     def __len__(self):
-        return len(self._frame_paths)
+        return len(self._dataset_indices_info)
 
-    def _get_frame_path(self, label_row: LabelRowV2, frame: int) -> Path:
+    def _get_frame_file(self, label_row: LabelRowV2, frame: int) -> Path:
         return get_frame_file(
             data_dir=self._cache_dir,
             project_hash=self._project.project_hash,
@@ -56,12 +59,47 @@ class EncordDataset(Dataset):
             frame=frame,
         )
 
-    def _get_label_row_annotations(self, label_row: LabelRowV2) -> Path:
+    def _get_label_row_annotations_file(self, label_row: LabelRowV2) -> Path:
         return get_label_row_annotations_file(
             data_dir=self._cache_dir,
             project_hash=self._project.project_hash,
             label_row_hash=label_row.label_hash,
         )
+
+    def _ensure_answers_availability(self) -> dict:
+        lrs_info_file = get_label_rows_info_file(self._cache_dir, self._project.project_hash)
+        label_rows_info: dict = json.loads(lrs_info_file.read_text(encoding="utf-8"))
+        should_update_info = False
+        class_name_to_idx = {name: idx for idx, name in enumerate(self.class_names)}  # Fast lookup of class indices
+        for label_row in self._label_rows:
+            if "answers" not in label_rows_info[label_row.label_hash]:
+                if not label_row.is_labelling_initialised:
+                    # Retrieve label row content from local storage
+                    anns_path = self._get_label_row_annotations_file(label_row)
+                    label_row.from_labels_dict(json.loads(anns_path.read_text(encoding="utf-8")))
+
+                answers = dict()
+                for frame_view in label_row.get_frame_views():
+                    clf_instances = frame_view.get_classification_instances(self._classification)
+                    # Skip frames where the input classification is missing
+                    if len(clf_instances) == 0:
+                        continue
+
+                    clf_instance = clf_instances[0]
+                    clf_answer = clf_instance.get_answer(self._attribute)
+                    # Skip frames where the input classification has no answer (probable annotation error)
+                    if clf_answer is None:
+                        continue
+
+                    answers[frame_view.frame] = {
+                        "image_file": self._get_frame_file(label_row, frame_view.frame).as_posix(),
+                        "label": class_name_to_idx[clf_answer.title],
+                    }
+                label_rows_info[label_row.label_hash]["answers"] = answers
+                should_update_info = True
+        if should_update_info:
+            lrs_info_file.write_text(json.dumps(label_rows_info), encoding="utf-8")
+        return label_rows_info
 
     def _setup(
         self,
@@ -107,23 +145,15 @@ class EncordDataset(Dataset):
             **kwargs,
         )
 
-        self._frame_paths = []
-        self._labels = []
-        class_name_to_idx = {name: idx for idx, name in enumerate(self.class_names)}  # Fast lookup of class indices
+        # Prepare data for the __getitem__ method
+        self._dataset_indices_info: list[EncordDataset.DatasetIndexInfo] = []
+        label_rows_info = self._ensure_answers_availability()
         for label_row in self._label_rows:
-            anns_path = self._get_label_row_annotations(label_row)
-            label_row.from_labels_dict(json.loads(anns_path.read_text(encoding="utf-8")))
-            for frame_view in label_row.get_frame_views():
-                clf_instances = frame_view.get_classification_instances(self._classification)
-                # Skip frames where the input classification is missing
-                if len(clf_instances) == 0:
-                    continue
+            answers: dict[int, Any] = label_rows_info[label_row.label_hash]["answers"]
+            for frame_num in sorted(answers.keys()):
+                self._dataset_indices_info.append(EncordDataset.DatasetIndexInfo(**answers[frame_num]))
 
-                clf_instance = clf_instances[0]
-                clf_answer = clf_instance.get_answer(self._attribute)
-                # Skip frames where the input classification has no answer (probable annotation error)
-                if clf_answer is None:
-                    continue
-
-                self._frame_paths.append(self._get_frame_path(label_row, frame_view.frame))
-                self._labels.append(class_name_to_idx[clf_answer.title])
+    @dataclass
+    class DatasetIndexInfo:
+        image_file: Path | str
+        label: int


### PR DESCRIPTION
Use an internal project json to record the label rows that have been completely downloaded, thus avoiding any further check on their images. Also, after the first time the image files and labels are calculated they will be saved for easy access in future runs.

Also, label rows' contents that are already up-to-date won't be downloaded again, even when `overwrite_annotations` is set to `True` (via last edited datetime comparison).
